### PR TITLE
Feat/clamp domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ The values are obfuscated by perturbing them with random values sampled from a l
 
 Optionally, true zero values can be returned unperturbed. While lowering the privacy level slightly, this can vastly improve subsequent processes for data access control.
 
+If the optional clamping of the Laplace distribution's domain is used for restricting the permutation to the interval `[-clamping_domain, clamping_domain]`, the security properties change: the mechanism is no longer `$(\epsilon,0)$`-differentially private, but only fulfils `$(\epsilon,\delta)$`-differential privacy. The parameter can be calculated as `$\delta(\epsilon,\Delta)=\sup_S\left(Pr[Z\in S]-e^\epsilon Pr[Z\in S-\Delta]\right)_+$` which is the positive supremum.
+
 ## Dependencies
 
 The dependencies Samply.Laplace Rust library requires are:
@@ -36,6 +38,7 @@ const DELTA: f64 = 1.;
 const EPSILON: f64 = 0.1;
 const MU: f64 = 0.;
 const ROUNDING_STEP: usize = 10;
+const clamping_domain = None;
 
 
 fn obfuscate -> Result<u64, LaplaceError> {
@@ -53,6 +56,7 @@ fn obfuscate -> Result<u64, LaplaceError> {
 	    false, // A flag indicating whether zero counts should be obfuscated.
 	    ObfuscateBelow10Mode::Ten, // 0 - return 0, 1 - return 10, 2 - obfuscate using Laplace distribution and rounding
 	    ROUNDING_STEP, // The granularity of the rounding.
+			clamping_domain, // Optional clamping of the Laplace distributions's domain
 	    &mut rng, // A secure random generator for seeded randomness.
 	)?;
 	

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The values are obfuscated by perturbing them with random values sampled from a l
 
 Optionally, true zero values can be returned unperturbed. While lowering the privacy level slightly, this can vastly improve subsequent processes for data access control.
 
-If the optional clamping of the Laplace distribution's domain is used for restricting the permutation to the interval `[-clamping_domain, clamping_domain]`, the security properties change: the mechanism is no longer `$(\epsilon,0)$`-differentially private, but only fulfils `$(\epsilon,\delta)$`-differential privacy. The parameter can be calculated as `$\delta(\epsilon,\Delta)=\sup_S\left(Pr[Z\in S]-e^\epsilon Pr[Z\in S-\Delta]\right)_+$` which is the positive supremum.
+If the optional clamping of the Laplace distribution's domain is used for restricting the permutation to the interval `[-clamping_domain, clamping_domain]`, the security properties change: the mechanism is no longer $`(\epsilon,0)`$-differentially private, but only fulfils $`(\epsilon,\delta)`$-differential privacy. The parameter can be calculated as $`\delta(\epsilon,\Delta)=\sup_S\left(Pr[Z\in S]-e^\epsilon Pr[Z\in S-\Delta]\right)_+`$ which is the positive supremum.
 
 ## Dependencies
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ The values are obfuscated by perturbing them with random values sampled from a l
 
 Optionally, true zero values can be returned unperturbed. While lowering the privacy level slightly, this can vastly improve subsequent processes for data access control.
 
-If the optional clamping of the Laplace distribution's domain is used for restricting the permutation to the interval `[-clamping_domain, clamping_domain]`, the security properties change: the mechanism is no longer $`(\epsilon,0)`$-differentially private, but only fulfils $`(\epsilon,\delta)`$-differential privacy. The parameter can be calculated as $`\delta(\epsilon,\Delta)=\sup_S\left(Pr[Z\in S]-e^\epsilon Pr[Z\in S-\Delta]\right)_+`$ which is the positive supremum.
+If the optional parameter limiting the domain of the Laplace distribution is used, restricting the perturbation to the interval `[-domain_limit, domain_limit]`, the security properties change: the mechanism is no longer $`(\epsilon,0)`$-differentially private but instead only fulfills $`(\epsilon,\delta)`$-differential privacy. The parameter can be calculated as $`\delta(\epsilon,\Delta)=\sup_S\left(Pr[Z\in S]-e^\epsilon Pr[Z\in S-\Delta]\right)_+`$.
 
 ## Dependencies
 
@@ -38,7 +38,7 @@ const DELTA: f64 = 1.;
 const EPSILON: f64 = 0.1;
 const MU: f64 = 0.;
 const ROUNDING_STEP: usize = 10;
-const clamping_domain = None;
+const domain_limit = None;
 
 
 fn obfuscate -> Result<u64, LaplaceError> {
@@ -56,7 +56,7 @@ fn obfuscate -> Result<u64, LaplaceError> {
 	    false, // A flag indicating whether zero counts should be obfuscated.
 	    ObfuscateBelow10Mode::Ten, // 0 - return 0, 1 - return 10, 2 - obfuscate using Laplace distribution and rounding
 	    ROUNDING_STEP, // The granularity of the rounding.
-			clamping_domain, // Optional clamping of the Laplace distributions's domain
+			domain_limit, // Optional limitation to the domain of the Laplace distributions
 	    &mut rng, // A secure random generator for seeded randomness.
 	)?;
 	

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,8 +5,8 @@ use thiserror::Error;
 pub enum LaplaceError {
     #[error("Unable to create Laplace distribution: {0}")]
     DistributionCreationError(StatsError),
-    #[error("Invalid clamping domain. Must be None or non-zero positive number")]
-    InvalidClamping,
+    #[error("Invalid domain limit. Must be None or a positive non-zero number")]
+    InvalidDomain,
     #[error("Rounding step zero not allowed")]
     InvalidArgRoundingStepZero,
     #[error("Rounding step error: {0}")]

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -5,6 +5,8 @@ use thiserror::Error;
 pub enum LaplaceError {
     #[error("Unable to create Laplace distribution: {0}")]
     DistributionCreationError(StatsError),
+    #[error("Invalid clamping domain. Must be None or non-zero positive number")]
+    InvalidClamping,
     #[error("Rounding step zero not allowed")]
     InvalidArgRoundingStepZero,
     #[error("Rounding step error: {0}")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -159,7 +159,7 @@ fn round_parametric(value: f64, step_parameter: usize) -> Result<u64, LaplaceErr
 ///
 /// * `mu` - the mean of the distribution.
 /// * `b` - the scale parameter of the distribution, often equal to `sensitivity`/`epsilon`.
-/// /// * `rng` - random generator.
+/// * `rng` - random generator.
 ///
 /// # Returns
 ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,8 +165,7 @@ fn round_parametric(value: f64, step_parameter: usize) -> Result<u64, LaplaceErr
 ///
 /// Returns a random sample from the Laplace distribution with the given `mu` and `b`, or an error if the distribution creation failed.
 fn laplace(mu: f64, b: f64, rng: &mut rand::rngs::ThreadRng) -> Result<f64, LaplaceError> {
-    let dist =
-        Laplace::new(mu, b).map_err(|e| LaplaceError::DistributionCreationError(e))?;
+    let dist = Laplace::new(mu, b).map_err(LaplaceError::DistributionCreationError)?;
     Ok(dist.sample(rng))
 }
 


### PR DESCRIPTION
This PR allows to optionally specify a clamping domain for the laplace distribution. This is a braking change, as is changes the signature of the librarie's main function.